### PR TITLE
Add support for 100g & 50g interfaces on Cisco IOS XE devices

### DIFF
--- a/custom_components/snmp_switch_manager/helpers.py
+++ b/custom_components/snmp_switch_manager/helpers.py
@@ -13,12 +13,17 @@ def _abbr_from_speed_or_name(name: str) -> str:
         return "Tw"
     if n.startswith("fa"):
         return "Fa"
+    if n.startswith("fi"):
+        return "Fi"
+    if n.startswith("hu"):
+        return "Hu"
     if n.startswith("po") or n.startswith("port-channel") or n.startswith("portchannel"):
         return "Po"
     if n.startswith("lo"):
         return "Lo"
     if n.startswith("vl"):
         return "Vl"
+    if "100g" in n: return "Hu"
     if "10g" in n: return "Te"
     if "20g" in n: return "Tw"
     if "1g" in n or "1000" in n: return "Gi"


### PR DESCRIPTION
Add handling for 'Fi' and 'Hu' prefixes in the helper function.

