### PR TITLE
fix: comprehensive HA best-practices and performance remediation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,117 @@
+# Copilot Instructions
+
+## What this is
+
+A Home Assistant custom integration that manages SNMP-enabled network switches. It discovers interfaces via SNMP and exposes them as HA entities: switch entities (port admin up/down), diagnostic sensors (hostname, model, firmware, uptime), optional bandwidth sensors (RX/TX throughput), environmental sensors (CPU, memory, temperature, fans, PSU), and PoE statistics. A custom Lovelace card provides a physical switch visualization.
+
+Integration domain: `snmp_switch_manager`  
+Minimum HA version: `2025.11.2`  
+SNMP library: `pysnmp 7.x` (auto-installed by HA; compatibility shim in `snmp_compat.py`)
+
+## Build, lint, and validation
+
+**Check for Python syntax errors:**
+```bash
+python -m compileall custom_components/snmp_switch_manager/
+```
+
+**CI runs automatically via GitHub Actions on push/PR:**
+- `.github/workflows/ci.yaml` — Python compile check + Node lint
+- `.github/workflows/hassfest.yaml` — HA integration schema validation
+- `.github/workflows/hacs.yaml` — HACS repository compliance
+
+There are no unit tests or pytest setup. Validation is via HA's `hassfest` tool and Python compile checks only.
+
+## Architecture
+
+### Data flow
+
+```
+SwitchSnmpClient (snmp.py)
+  └─ client.cache          ← single source of truth for all SNMP state
+       ├─ ifTable           ← interface records keyed by ifIndex
+       ├─ bandwidth         ← per-interface throughput counters
+       ├─ poe_*             ← PoE budget/used/available
+       └─ env_*             ← CPU, memory, temperature, fans, PSU
+
+DataUpdateCoordinator (__init__.py)
+  └─ calls client.async_poll() on each update interval
+  └─ entities read from coordinator.data (which is client.cache)
+```
+
+All entities are **read-only consumers of `client.cache`** — they never call SNMP directly. The coordinator drives all polling.
+
+### Polling strategy
+
+The main coordinator polls every 10 seconds (default). Within each poll, different data types are throttled independently:
+
+| Data | Default interval | Config key |
+|------|-----------------|------------|
+| Interface state (admin/oper) | 10s (every poll) | `CONF_POLL_INTERVAL` |
+| Uptime | 300s | `CONF_UPTIME_POLL_INTERVAL` |
+| Bandwidth counters | 30s | `CONF_BW_POLL_INTERVAL` |
+| PoE stats | 30s | `CONF_POE_POLL_INTERVAL` |
+| Environmental | 30s | `CONF_ENV_POLL_INTERVAL` |
+
+Bandwidth, PoE, and environmental polling only activate when their respective features are enabled in options.
+
+### Entity ID patterns
+
+- Port switches: `switch.{hostname}_{interface_name}`
+- Sensors: `sensor.{hostname}_{metric}`
+- Unique IDs: `{entry_id}-if-{ifIndex}` (stable across restarts; must not change)
+
+### Config flow structure
+
+`config_flow.py` (1,779 lines) implements a **hierarchical options menu** via `OptionsFlowHandler`. The flow uses a mutable `_options` dict and only triggers a reload if options actually changed. Top-level menu branches:
+
+- Connection & Name
+- Manage Interfaces (include/exclude/rename rules, icon rules, IP display)
+- Bandwidth Sensors (enable/mode/poll interval/rules)
+- Environmental Sensors (enable/PoE/env modes and intervals)
+- Custom OIDs (per-device diagnostic OID overrides)
+
+## Key conventions
+
+### Naming
+- Constants: `CONF_*` (config keys), `OID_*` (SNMP OIDs), `DEFAULT_*` (defaults) — all in `const.py`
+- Async methods: `async_*` prefix (e.g., `async_poll`, `async_initialize`)
+- Private methods/attributes: `_` prefix
+
+### Adding a new sensor type
+1. Define any new OIDs in `const.py`
+2. Collect the data in `snmp.py` — add to `async_poll()` and store in `self.cache`
+3. Add config keys to `const.py` and expose them in `config_flow.py` if user-configurable
+4. Create the entity class in `sensor.py` (or `switch.py`) reading from `coordinator.data`
+5. Register the entity in `async_setup_entry()` in `__init__.py`
+
+### SNMP operations
+- All SNMP calls are `async`; use `UdpTransportTarget.create()` (pysnmp 7.x via `snmp_compat.py`)
+- Multi-OID GETs are chunked to avoid PDU size limits
+- Missing OIDs must be handled gracefully — never crash polling; use fallback chains
+- Vendor-specific OIDs follow a cascade: vendor OID → standard MIB → `None`
+
+### Rule engine
+Interface include/exclude and rename rules are stored as user-readable pattern strings but compiled to regexes at runtime. Rules are applied in `__init__.py` (`_postprocess_if_names`, `_apply_port_rename_all`) after each coordinator update, not inside `snmp.py`.
+
+### Options flow state
+`OptionsFlowHandler` accumulates changes in `self._options` (a copy of `entry.options`). Changes are only written back to the config entry — and a reload triggered — if the new options dict differs from the current one.
+
+### ifTable record structure
+Each entry in `client.cache["ifTable"]` (keyed by `ifIndex` int) contains:
+```python
+{
+    "index": int, "name": str, "descr": str, "alias": str,
+    "speed_bps": int, "admin": int, "oper": int,
+    "vlan_id": int, "allowed_vlans": [int], "is_trunk": bool,
+    "port_type": str,   # "physical", "virtual", "unknown"
+    "if_type": int,     # IF-MIB ifType value
+    "ipv4": [...], "ip": str, "netmask": str, "cidr": int,
+    "display_name": str
+}
+```
+`display_name` is the post-processed name after rename rules are applied; use it for entity names and attributes.
+
+## Versioning
+
+Follows semantic versioning. Version is in `custom_components/snmp_switch_manager/manifest.json`. Update `CHANGELOG.md` with each release using the existing format.

--- a/custom_components/snmp_switch_manager/__init__.py
+++ b/custom_components/snmp_switch_manager/__init__.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     DOMAIN,
     PLATFORMS,
     DEFAULT_POLL_INTERVAL,
+    CONF_POLL_INTERVAL,
+    MIN_POLL_INTERVAL,
+    MAX_POLL_INTERVAL,
     CONF_BANDWIDTH_POLL_INTERVAL,
     DEFAULT_BANDWIDTH_POLL_INTERVAL,
     CONF_CUSTOM_OIDS,
@@ -42,15 +47,25 @@ from .const import (
     CONF_HIDE_IP_ON_PHYSICAL,
     CONF_HIDE_IP_ON_PHYSICAL_INTERFACES,
 )
-from .snmp import SwitchSnmpClient
+from .snmp import SwitchSnmpClient, SnmpAuthError
 from .helpers import get_snmp_connection_settings
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class SnmpSwitchRuntimeData:
+    """Runtime data stored on a config entry (replaces hass.data[DOMAIN][entry_id])."""
+
+    client: SwitchSnmpClient
+    coordinator: DataUpdateCoordinator
+
 
 # Use standard aliasing compatible with Python <3.12
 SwitchManagerConfigEntry = ConfigEntry
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    await async_register_services(hass)
     return True
 
 
@@ -132,6 +147,8 @@ def _postprocess_if_names(data: dict, options: dict) -> dict:
         if renamed != raw and "name_raw" not in row:
             row["name_raw"] = raw
         row["name"] = renamed
+        # Keep display_name in sync so platform consumers don't re-apply rules.
+        row["display_name"] = renamed
     return data
 
 
@@ -175,7 +192,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: SwitchManagerConfigEntry
         poe_options=poe_options,
         env_options=env_options,
     )
-    await client.async_initialize()
+    try:
+        await client.async_initialize()
+    except SnmpAuthError as exc:
+        raise ConfigEntryAuthFailed(
+            f"SNMP authentication failed for {host}: {exc}"
+        ) from exc
 
     # Apply per-device option for sysUpTime throttling
     client.set_uptime_poll_interval(entry.options.get(CONF_UPTIME_POLL_INTERVAL, DEFAULT_UPTIME_POLL_INTERVAL))
@@ -188,7 +210,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: SwitchManagerConfigEntry
         hass,
         _LOGGER,
         name=f"{DOMAIN}-coordinator-{host}",
-        update_interval=timedelta(seconds=DEFAULT_POLL_INTERVAL),
+        update_interval=timedelta(seconds=max(
+            MIN_POLL_INTERVAL,
+            min(
+                MAX_POLL_INTERVAL,
+                int(entry.options.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL) or DEFAULT_POLL_INTERVAL),
+            ),
+        )),
         # IMPORTANT: use the client's poll method directly. The client is
         # responsible for handling/guarding poll errors so we don't mark all
         # coordinator-backed entities unavailable.
@@ -196,13 +224,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SwitchManagerConfigEntry
     )
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        "client": client,
-        "coordinator": coordinator,
-    }
-
-    # Register services (idempotent)
-    await async_register_services(hass)
+    entry.runtime_data = SnmpSwitchRuntimeData(client=client, coordinator=coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -216,7 +238,12 @@ async def _async_update_listener(hass: HomeAssistant, entry: SwitchManagerConfig
 async def async_unload_entry(hass: HomeAssistant, entry: SwitchManagerConfigEntry) -> bool:
     unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unloaded:
-        hass.data[DOMAIN].pop(entry.entry_id, None)
+        runtime: SnmpSwitchRuntimeData | None = getattr(entry, "runtime_data", None)
+        if runtime is not None:
+            try:
+                await runtime.client.async_close()
+            except Exception:
+                pass
     return unloaded
 
 async def async_register_services(hass: HomeAssistant):
@@ -233,11 +260,12 @@ async def async_register_services(hass: HomeAssistant):
 
         # Resolve the integration entry and client from the entity's config_entry_id
         entry_id = ent.config_entry_id
-        data = hass.data.get(DOMAIN, {}).get(entry_id)
-        if not data:
+        config_entry = hass.config_entries.async_get_entry(entry_id)
+        runtime: SnmpSwitchRuntimeData | None = getattr(config_entry, "runtime_data", None) if config_entry else None
+        if not runtime:
             return
 
-        client = data["client"]
+        client = runtime.client
         # Parse if_index from our unique_id pattern "<entry_id>-if-<index>"
         unique_id = ent.unique_id or ""
         try:
@@ -246,7 +274,7 @@ async def async_register_services(hass: HomeAssistant):
             return
 
         await client.set_alias(if_index, description)
-        await data["coordinator"].async_request_refresh()
+        await runtime.coordinator.async_request_refresh()
 
     if not hass.services.has_service(DOMAIN, "set_port_description"):
         hass.services.async_register(DOMAIN, "set_port_description", handle_set_alias)

--- a/custom_components/snmp_switch_manager/const.py
+++ b/custom_components/snmp_switch_manager/const.py
@@ -8,6 +8,9 @@ CONF_COMMUNITY = "community"
 
 DEFAULT_PORT = 161
 DEFAULT_POLL_INTERVAL = 10  # seconds
+CONF_POLL_INTERVAL = "poll_interval"
+MIN_POLL_INTERVAL = 5    # seconds
+MAX_POLL_INTERVAL = 300  # seconds
 
 PLATFORMS = ["sensor", "switch"]
 

--- a/custom_components/snmp_switch_manager/manifest.json
+++ b/custom_components/snmp_switch_manager/manifest.json
@@ -13,6 +13,8 @@
   "loggers": [
     "pysnmp"
   ],
-  "requirements": [],
+  "requirements": [
+    "pysnmp>=6.2.6"
+  ],
   "version": "0.5.1-beta.4"
 }

--- a/custom_components/snmp_switch_manager/sensor.py
+++ b/custom_components/snmp_switch_manager/sensor.py
@@ -106,15 +106,9 @@ class EnvironmentBaseSensor(CoordinatorEntity, SensorEntity):
         return self._device_info
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    entry_data = hass.data[DOMAIN][entry.entry_id]
-    client: SwitchSnmpClient = entry_data["client"]
-    coordinator = entry_data["coordinator"]
-
-    # Ensure coordinator has initial data so we can create only supported sensors
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except Exception:
-        pass
+    runtime = entry.runtime_data
+    client: SwitchSnmpClient = runtime.client
+    coordinator = runtime.coordinator
 
     coord_data = coordinator.data or {}
 

--- a/custom_components/snmp_switch_manager/snmp.py
+++ b/custom_components/snmp_switch_manager/snmp.py
@@ -21,6 +21,7 @@ from .snmp_compat import (
     ObjectIdentity,
     get_cmd,
     next_cmd,
+    bulk_walk_cmd,
     set_cmd,
     OctetString,
     Integer,
@@ -171,6 +172,29 @@ OID_routeCol = "1.3.6.1.2.1.4.24.7.1.9"
 
 # ---------- low-level sync helpers offloaded by compat -------------
 
+# Phrases in pysnmp errorIndication that indicate authentication failure.
+_AUTH_ERROR_PHRASES = (
+    "wrongdigest",
+    "unknownusernam",
+    "authorizationerror",
+    "notintimewindow",
+    "unknownsecurityname",
+    "unsupportedsecuritylevel",
+)
+
+
+def _is_auth_error(err_ind: Any) -> bool:
+    """Return True when err_ind indicates an SNMP authentication/security failure."""
+    if err_ind is None:
+        return False
+    s = str(err_ind).lower()
+    return any(phrase in s for phrase in _AUTH_ERROR_PHRASES)
+
+
+class SnmpAuthError(Exception):
+    """Raised when SNMP authentication fails; triggers ConfigEntryAuthFailed."""
+
+
 async def _do_get_one(engine, community, target, context, oid: str) -> Optional[str]:
     err_ind, err_stat, err_idx, vbs = await get_cmd(
         engine,
@@ -180,6 +204,8 @@ async def _do_get_one(engine, community, target, context, oid: str) -> Optional[
         ObjectType(ObjectIdentity(oid)),
         lookupMib=False,  # <<< prevent FS MIB access
     )
+    if _is_auth_error(err_ind):
+        raise SnmpAuthError(str(err_ind))
     if err_ind or err_stat:
         return None
     for vb in vbs:
@@ -251,8 +277,46 @@ async def _do_get_many(engine, community, target, context, oids: list[str]) -> D
 async def _do_next_walk(
     engine, community, target, context, base_oid: str
 ) -> Iterable[Tuple[str, Any]]:
-    current_oid = base_oid
+    """Walk an OID subtree using GETBULK (max-repetitions=25), falling back to GETNEXT.
+
+    GETBULK dramatically reduces round-trips: a 48-port switch walk that needed 48+
+    individual requests with GETNEXT completes in 2–3 requests with GETBULK.
+    """
     seen: set[str] = set()
+
+    # --- GETBULK attempt --------------------------------------------------
+    try:
+        async for err_ind, err_stat, err_idx, vb_list in bulk_walk_cmd(
+            engine,
+            community,
+            target,
+            context,
+            0,  # non-repeaters
+            25,  # max-repetitions
+            ObjectType(ObjectIdentity(base_oid)),
+            lexicographicMode=False,
+            lookupMib=False,
+        ):
+            if err_ind or err_stat:
+                # Device doesn't support GETBULK (e.g. SNMPv1) — fall through
+                raise StopAsyncIteration
+            for vb in vb_list if isinstance(vb_list, (list, tuple)) else [vb_list]:
+                oid_obj, val = vb
+                oid_str = str(oid_obj)
+                if not (oid_str == base_oid or oid_str.startswith(base_oid + ".")):
+                    return
+                if oid_str in seen:
+                    return
+                seen.add(oid_str)
+                yield oid_str, val
+        return
+    except StopAsyncIteration:
+        pass
+    except Exception:
+        pass
+
+    # --- GETNEXT fallback (SNMPv1 or bulk_walk_cmd unavailable) ----------
+    current_oid = base_oid
     while True:
         err_ind, err_stat, err_idx, vbs = await next_cmd(
             engine,
@@ -261,7 +325,7 @@ async def _do_next_walk(
             context,
             ObjectType(ObjectIdentity(current_oid)),
             lexicographicMode=False,
-            lookupMib=False,  # <<< prevent FS MIB access
+            lookupMib=False,
         )
         if err_ind or err_stat or not vbs:
             break
@@ -373,6 +437,14 @@ class SwitchSnmpClient:
         self._last_uptime_poll: float = 0.0
         self._uptime_poll_interval: float = 300.0
 
+        # IPv4 address data rarely changes; throttle refreshes independently.
+        self._last_ipv4_poll: float = 0.0
+        self._ipv4_poll_interval: float = 300.0
+
+        # Vendor-specific firmware/model OIDs (CBS350, Zyxel, MikroTik) never
+        # change at runtime; fetch once during async_initialize and skip on polls.
+        self._vendor_oids_fetched: bool = False
+
     def _custom_oid(self, key: str) -> Optional[str]:
         val = (self.custom_oids or {}).get(key)
         if not val:
@@ -456,32 +528,67 @@ class SwitchSnmpClient:
         if self.engine is not None:
             return
 
-        def _build_engine_with_minimal_preload():
+        def _build_engine_and_preload_mibs():
             eng = SnmpEngine()
             try:
                 mib_builder = eng.getMibBuilder()
-                # Pre-load core pysnmp modules off the event loop.
-                # Home Assistant flags synchronous FS access (os.listdir/open) from pysnmp's MIB loader
-                # when it occurs on the asyncio loop thread. Preloading here ensures pysnmp will not
-                # hit the filesystem later during async polling/walks.
+                # Pre-load ALL MIB modules used by this integration off the event loop.
+                # Home Assistant flags synchronous FS access (os.listdir/open) from pysnmp's
+                # MIB loader when it occurs on the asyncio loop thread. Preloading here
+                # ensures pysnmp will not hit the filesystem during async polling/walks.
+                #
+                # Modules covered:
+                #   - Core SMI / ASN.1 machinery (SNMPv2-SMI, SNMPv2-TC, …)
+                #   - SNMPv3 USM / framework (needed for v3 auth/priv negotiation)
+                #   - IF-MIB types (OctetString counters, ifType enumerations)
+                #   - ENTITY-MIB, HOST-RESOURCES-MIB, BRIDGE-MIB, Q-BRIDGE-MIB
+                #   - IP-MIB, POWER-ETHERNET-MIB
                 mib_builder.loadModules(
+                    # Core / SMI
                     "SNMPv2-SMI",
                     "SNMPv2-TC",
                     "SNMPv2-CONF",
                     "SNMPv2-MIB",
                     "__SNMPv2-MIB",
+                    # SNMPv3
                     "SNMP-FRAMEWORK-MIB",
                     "SNMP-COMMUNITY-MIB",
                     "SNMP-TARGET-MIB",
                     "SNMP-NOTIFICATION-MIB",
                     "SNMPv2-TM",
                     "PYSNMP-SOURCE-MIB",
+                    # Interface MIBs
+                    "IF-MIB",
+                    "IANAifType-MIB",
+                    # Entity / hardware inventory
+                    "ENTITY-MIB",
+                    # IP address tables
+                    "IP-MIB",
+                    # Bridge / VLAN MIBs
+                    "BRIDGE-MIB",
+                    "Q-BRIDGE-MIB",
+                    # Host resources (CPU / memory fallback)
+                    "HOST-RESOURCES-MIB",
+                    "HOST-RESOURCES-TYPES",
+                    # PoE
+                    "POWER-ETHERNET-MIB",
                 )
             except Exception:
+                # loadModules is best-effort; some MIBs may not ship with the installed
+                # pysnmp version. Any that were loaded are already cached; missing ones
+                # will trigger a one-time lazy load but that is a minor fallback.
                 pass
+
+            # Disable all MIB source search paths after preloading so that pysnmp
+            # cannot fall back to filesystem access during async event-loop operations.
+            try:
+                mib_builder.setMibSources()  # empty → no further FS searches
+            except Exception:
+                pass
+
             return eng
 
-        self.engine = await self.hass.async_add_executor_job(_build_engine_with_minimal_preload)
+        self.engine = await self.hass.async_add_executor_job(_build_engine_and_preload_mibs)
 
     async def _ensure_target(self) -> None:
         if self.target is None:
@@ -489,9 +596,37 @@ class SwitchSnmpClient:
 
     # ---------- lifecycle / fetch ----------
 
+    async def async_close(self) -> None:
+        """Release pysnmp resources (transport handles, background tasks).
+
+        Must be called from async_unload_entry to prevent resource leaks on
+        integration reload or reconfiguration.
+        """
+        if self.engine is None:
+            return
+        try:
+            # pysnmp 7.x (v3arch asyncio): close the transport dispatcher.
+            dispatcher = getattr(self.engine, "transportDispatcher", None)
+            if dispatcher is not None:
+                if hasattr(dispatcher, "closeDispatcher"):
+                    dispatcher.closeDispatcher()
+        except Exception:
+            pass
+        finally:
+            self.engine = None
+            self.target = None
+
     async def async_initialize(self) -> None:
         await self._ensure_engine()
         await self._ensure_target()
+
+        # Issue a warm-up GET on the event loop to flush any remaining lazy pysnmp
+        # internal state (PDU type registry, transport layer) before the real walks
+        # begin. This is a best-effort call — errors are intentionally ignored.
+        try:
+            await self._async_get_one(OID_sysDescr)
+        except Exception:
+            pass
 
         # Build interface table and state first (names, alias, admin/oper)
         await self._async_walk_interfaces(dynamic_only=False)
@@ -499,6 +634,7 @@ class SwitchSnmpClient:
         # Build IPv4 maps and attach to interfaces (original repo logic)
         await self._async_walk_ipv4()
         self._attach_ipv4_to_interfaces()
+        self._last_ipv4_poll = time.monotonic()
 
         # System fields
         self.cache["sysDescr"] = await self._async_get_one(OID_sysDescr)
@@ -638,28 +774,47 @@ class SwitchSnmpClient:
         if not dynamic_only:
             self.cache["ifTable"] = {}
 
+            # Walk all static interface columns in parallel.
+            (
+                idx_rows,
+                descr_rows,
+                name_rows,
+                alias_rows,
+                speed_rows,
+                hispeed_rows,
+                iftype_rows,
+            ) = await asyncio.gather(
+                self._async_walk(OID_ifIndex),
+                self._async_walk(OID_ifDescr),
+                self._async_walk(OID_ifName),
+                self._async_walk(OID_ifAlias),
+                self._async_walk(OID_ifSpeed),
+                self._async_walk(OID_ifHighSpeed),
+                self._async_walk(OID_ifType),
+            )
+
             # Indexes
-            for oid, val in await self._async_walk(OID_ifIndex):
+            for oid, val in idx_rows:
                 idx = int(oid.split(".")[-1])
                 self.cache["ifTable"][idx] = {"index": idx}
 
             # Descriptions
-            for oid, val in await self._async_walk(OID_ifDescr):
+            for oid, val in descr_rows:
                 idx = int(oid.split(".")[-1])
                 self.cache["ifTable"].setdefault(idx, {})["descr"] = str(val)
 
             # Names
-            for oid, val in await self._async_walk(OID_ifName):
+            for oid, val in name_rows:
                 idx = int(oid.split(".")[-1])
                 self.cache["ifTable"].setdefault(idx, {})["name"] = str(val)
 
             # Aliases
-            for oid, val in await self._async_walk(OID_ifAlias):
+            for oid, val in alias_rows:
                 idx = int(oid.split(".")[-1])
                 self.cache["ifTable"].setdefault(idx, {})["alias"] = str(val)
 
             # Speeds (prefer ifHighSpeed where present; fall back to ifSpeed)
-            for oid, val in await self._async_walk(OID_ifSpeed):
+            for oid, val in speed_rows:
                 idx = int(oid.split(".")[-1])
                 try:
                     bps = _parse_numeric(val)
@@ -670,7 +825,7 @@ class SwitchSnmpClient:
                 if bps > 0:
                     self.cache["ifTable"].setdefault(idx, {})["speed_bps"] = bps
 
-            for oid, val in await self._async_walk(OID_ifHighSpeed):
+            for oid, val in hispeed_rows:
                 idx = int(oid.split(".")[-1])
                 try:
                     v = int(val)
@@ -682,8 +837,20 @@ class SwitchSnmpClient:
                     bps = v if v >= 1_000_000 else v * 1_000_000
                     self.cache["ifTable"].setdefault(idx, {})["speed_bps"] = bps
 
+            # ifType (needed for port classification)
+            for oid, val in iftype_rows:
+                idx = int(oid.split(".")[-1])
+                rec = self.cache["ifTable"].get(idx)
+                if rec is not None:
+                    try:
+                        rec["if_type"] = int(val)
+                    except Exception:
+                        rec["if_type"] = None
+
             # VLAN (PVID) mapping via BRIDGE-MIB / Q-BRIDGE-MIB
             # Map ifIndex -> dot1dBasePort -> dot1qPvid (untagged VLAN)
+            # Also capture bridge_ifindexes here to avoid a second walk later.
+            bridge_ifindexes: set[int] = set()
             try:
                 baseport_by_ifindex: Dict[int, int] = {}
                 for oid, val in await self._async_walk(OID_dot1dBasePortIfIndex):
@@ -698,6 +865,7 @@ class SwitchSnmpClient:
                         continue
                     if if_index > 0 and base_port > 0:
                         baseport_by_ifindex[if_index] = base_port
+                        bridge_ifindexes.add(if_index)
                 self.cache["ifindex_by_baseport"] = {v: k for k, v in baseport_by_ifindex.items() if v and k}
                 if baseport_by_ifindex:
                     pvid_by_baseport: Dict[int, int] = {}
@@ -830,27 +998,9 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                 ds = (rec.get("descr") or "").strip()
                 rec["display_name"] = nm or ds or f"ifIndex {idx}"
 
-        # Dynamic state only
-            # Interface types (IF-MIB ifType)
-            for oid, val in await self._async_walk(OID_ifType):
-                idx = int(oid.split(".")[-1])
-                rec = self.cache["ifTable"].get(idx)
-                if rec is not None:
-                    try:
-                        rec["if_type"] = int(val)
-                    except Exception:
-                        rec["if_type"] = None
-
             # Bridge membership (BRIDGE-MIB dot1dBasePortIfIndex)
-            bridge_ifindexes: set[int] = set()
-            try:
-                for oid, val in await self._async_walk(OID_dot1dBasePortIfIndex):
-                    try:
-                        bridge_ifindexes.add(int(val))
-                    except Exception:
-                        continue
-            except Exception:
-                bridge_ifindexes = set()
+            # bridge_ifindexes was already populated during the VLAN/PVID walk above
+            # and ifType was fetched in the parallel walk at the start of this block.
 
             for idx, rec in self.cache["ifTable"].items():
                 if not isinstance(rec, dict):
@@ -1159,8 +1309,15 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
         await self._ensure_engine()
         await self._ensure_target()
         await self._async_walk_interfaces(dynamic_only=True)
-        await self._async_walk_ipv4()
-        self._attach_ipv4_to_interfaces()
+        # IPv4 data rarely changes; throttle separately (default 300 s).
+        now_mono = time.monotonic()
+        if (
+            self._last_ipv4_poll == 0.0
+            or (now_mono - self._last_ipv4_poll) >= self._ipv4_poll_interval
+        ):
+            self._last_ipv4_poll = now_mono
+            await self._async_walk_ipv4()
+            self._attach_ipv4_to_interfaces()
 
     # ---------- coordinator hook ----------
     async def async_poll(self) -> Dict[str, Any]:
@@ -1228,7 +1385,9 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                         manufacturer = " ".join(toks[:-1])
 
                 # Cisco CBS350: prefer ENTITY-MIB software revision when available.
-                if (model_hint and "CBS" in model_hint) or ("CBS" in sd):
+                # Vendor-specific OIDs only fetched once — firmware/model never changes.
+                if not self._vendor_oids_fetched:
+                  if (model_hint and "CBS" in model_hint) or ("CBS" in sd):
                     try:
                         sw_rev = await _do_get_one(
                             self.engine,
@@ -1236,15 +1395,14 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                             self.target,
                             self.context,
                             OID_entPhysicalSoftwareRev_CBS350,
-                            OID_hwEntityTemperature,
                         )
                     except Exception:
                         sw_rev = None
                     if sw_rev:
                         firmware = sw_rev.strip() or firmware
 
-                # Zyxel: prefer vendor-specific manufacturer/firmware OIDs when detected
-                if "zyxel" in sd.lower():
+                  # Zyxel: prefer vendor-specific manufacturer/firmware OIDs when detected
+                  if "zyxel" in sd.lower():
                     try:
                         zy_mfg = await _do_get_one(
                             self.engine,
@@ -1271,8 +1429,8 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                     if zy_fw:
                         firmware = zy_fw.strip() or firmware
 
-                # MikroTik RouterOS: override using MIKROTIK-MIB when detected
-                if "mikrotik" in sd.lower() or "routeros" in sd.lower():
+                  # MikroTik RouterOS: override using MIKROTIK-MIB when detected
+                  if "mikrotik" in sd.lower() or "routeros" in sd.lower():
                     manufacturer = "MikroTik"
                     try:
                         mk_ver = await _do_get_one(
@@ -1298,6 +1456,8 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                         mk_model = None
                     if mk_model:
                         self.cache["model"] = mk_model.strip() or self.cache.get("model")
+
+                  self._vendor_oids_fetched = True
 
                 # Custom OIDs: per-device overrides take precedence over vendor logic and generic parsing
                 try:
@@ -1515,17 +1675,30 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
             if should_poll:
                 self._poe_last_poll = now_mono
 
+                # Fetch all PoE data tables in parallel.
+                (
+                    budget_rows,
+                    used_rows,
+                    dell_poe_rows,
+                    std_poe_rows,
+                ) = await asyncio.gather(
+                    self._async_walk("1.3.6.1.2.1.105.1.3.1.1.2"),
+                    self._async_walk("1.3.6.1.2.1.105.1.3.1.1.4"),
+                    self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.15.1.1.1.2.1"),
+                    self._async_walk("1.3.6.1.2.1.105.1.1.1.1.15"),
+                )
+
                 # --- (1) Standard PoE totals + health (POWER-ETHERNET-MIB) ---
-                budget_list, used_raw_list, health_list = [], [], []
+                budget_list, used_raw_list = [], []
 
                 try:
-                    for _, val in await self._async_walk("1.3.6.1.2.1.105.1.3.1.1.2"):
+                    for _, val in budget_rows:
                         n = _parse_numeric(val)
                         if n is not None and float(n) >= 0: budget_list.append(float(n))
                 except Exception: pass
 
                 try:
-                    for _, val in await self._async_walk("1.3.6.1.2.1.105.1.3.1.1.4"):
+                    for _, val in used_rows:
                         n = _parse_numeric(val)
                         if n is not None and float(n) >= 0: used_raw_list.append(float(n))
                 except Exception: pass
@@ -1552,7 +1725,7 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
 
                 # A) Dell Private MIB
                 try:
-                    for oid, val in await self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.15.1.1.1.2.1"):
+                    for oid, val in dell_poe_rows:
                         idx = int(str(oid).split(".")[-1])
                         mw = _parse_numeric(val)
                         if mw is not None: poe_power_mw[idx] = float(mw)
@@ -1561,7 +1734,7 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                 # B) Standard OID (with physical port translation for Zyxel/Aruba)
                 try:
                     ifindex_map = self.cache.get("ifindex_by_baseport", {})
-                    for oid, val in await self._async_walk("1.3.6.1.2.1.105.1.1.1.1.15"):
+                    for oid, val in std_poe_rows:
                         port_idx = int(str(oid).split(".")[-1])
                         # Map hardware port to Home Assistant ifIndex
                         target_idx = ifindex_map.get(port_idx, port_idx)
@@ -1599,12 +1772,35 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                 self._env_last_poll = now_mono
                 env_power_mw: Dict[int, float] = {}
 
-                # Dell N-Series (observed):
+                # Fetch all Dell OS6 environmental tables in parallel.
+                (
+                    dell_power_rows,
+                    mem_free_raw,
+                    mem_total_raw,
+                    cpu_raw,
+                    fans_rows,
+                    fan_status_rows,
+                    psu_status_rows,
+                    temps_rows,
+                    unit_temp_raw,
+                    unit_temp_state_raw,
+                ) = await asyncio.gather(
+                    self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.9.1.4.1"),
+                    self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.1.1.4.1.0"),
+                    self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.1.1.4.2.0"),
+                    self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.1.1.4.9.0"),
+                    self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.6.1.4.1"),
+                    self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.6.1.3.1"),
+                    self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.7.1.2.1"),
+                    self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.8.1.5.1"),
+                    self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.15.1.3.1"),
+                    self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.15.1.2.1"),
+                )
+
+                # Dell N-Series power
                 # 1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.9.1.4.1.<idx> = INTEGER: <mW>
-                # This aligns with CLI "show system" Current Power (Watts).
                 env_oid = "1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.9.1.4.1"
-                env_table = await self._async_walk(env_oid)
-                for oid, val in env_table:
+                for oid, val in dell_power_rows:
                     try:
                         env_idx = int(str(oid).split(".")[-1])
                     except Exception:
@@ -1620,27 +1816,21 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                 # Dell OS6 CPU / Memory / Fan metrics (best-effort; safe to ignore if not supported)
 
                 # Memory OIDs return values in KB on Dell OS6 (based on observed values).
-                # Values may come back as typed strings (e.g. "Gauge32: 12345"); parse numerics defensively.
                 try:
-                    mem_free_kb_raw = await self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.1.1.4.1.0")
-                    mem_free_kb = _parse_numeric(mem_free_kb_raw)
+                    mem_free_kb = _parse_numeric(mem_free_raw)
                     self.cache["env_mem_free_kb"] = int(mem_free_kb) if mem_free_kb is not None else None
                 except Exception:
                     self.cache["env_mem_free_kb"] = None
 
                 try:
-                    mem_total_kb_raw = await self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.1.1.4.2.0")
-                    mem_total_kb = _parse_numeric(mem_total_kb_raw)
+                    mem_total_kb = _parse_numeric(mem_total_raw)
                     self.cache["env_mem_total_kb"] = int(mem_total_kb) if mem_total_kb is not None else None
                 except Exception:
                     self.cache["env_mem_total_kb"] = None
 
                 try:
-                    cpu_s = str(await self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.1.1.4.9.0"))
+                    cpu_s = str(cpu_raw)
                     self.cache["env_cpu_raw"] = cpu_s
-                    # Observed example:
-                    #   "    5 Secs ( 10.5746%)   60 Secs ( 11.9951%)  300 Secs ( 12.3370%)"
-                    # Use a tolerant parse: grab the first 3 percentage-like numbers.
                     nums = re.findall(r"([0-9]+(?:\.[0-9]+)?)\s*%", cpu_s)
                     if len(nums) >= 3:
                         self.cache["env_cpu_5s"] = float(nums[0])
@@ -1657,7 +1847,7 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
 
                 try:
                     fans: dict[int, int] = {}
-                    for oid, val in await self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.6.1.4.1"):
+                    for oid, val in fans_rows:
                         try:
                             idx = int(str(oid).split(".")[-1])
                         except Exception:
@@ -1670,10 +1860,9 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                 except Exception:
                     self.cache["env_fans_rpm"] = None
 
-                # Fan status (observed: 2 = OK)
                 try:
                     fan_status: dict[int, int] = {}
-                    for oid, val in await self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.6.1.3.1"):
+                    for oid, val in fan_status_rows:
                         try:
                             idx = int(str(oid).split(".")[-1])
                         except Exception:
@@ -1686,10 +1875,9 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                 except Exception:
                     self.cache["env_fans_status"] = None
 
-                # PSU status (observed: 2 = OK)
                 try:
                     psu_status: dict[int, int] = {}
-                    for oid, val in await self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.7.1.2.1"):
+                    for oid, val in psu_status_rows:
                         try:
                             idx = int(str(oid).split(".")[-1])
                         except Exception:
@@ -1702,10 +1890,9 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                 except Exception:
                     self.cache["env_psu_status"] = None
 
-                # Temperatures (C) - includes "System Temperature" at index 0 on Dell OS6
                 try:
                     temps_c: dict[int, int] = {}
-                    for oid, val in await self._async_walk("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.8.1.5.1"):
+                    for oid, val in temps_rows:
                         try:
                             idx = int(str(oid).split(".")[-1])
                         except Exception:
@@ -1718,16 +1905,13 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                 except Exception:
                     self.cache["env_temps_c"] = None
 
-                # Unit/System temperature + state (Dell OS6)
                 try:
-                    raw = await self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.15.1.3.1")
-                    n = _parse_numeric(raw)
+                    n = _parse_numeric(unit_temp_raw)
                     self.cache["env_unit_temp_c"] = int(n) if n is not None else None
                 except Exception:
                     self.cache["env_unit_temp_c"] = None
                 try:
-                    raw = await self._async_get_one("1.3.6.1.4.1.674.10895.5000.2.6132.1.1.43.1.15.1.2.1")
-                    n = _parse_numeric(raw)
+                    n = _parse_numeric(unit_temp_state_raw)
                     self.cache["env_unit_temp_state"] = int(n) if n is not None else None
                 except Exception:
                     self.cache["env_unit_temp_state"] = None
@@ -1764,19 +1948,32 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                             types[idx] = int(n)
 
                         if types:
+                            # Fetch value, scale, precision, and oper-status columns in parallel.
+                            (
+                                value_rows,
+                                scale_rows,
+                                prec_rows,
+                                oper_rows,
+                            ) = await asyncio.gather(
+                                self._async_walk(ent_value_oid),
+                                self._async_walk(ent_scale_oid),
+                                self._async_walk(ent_prec_oid),
+                                self._async_walk(ent_oper_oid),
+                            )
+
                             values: dict[int, Any] = {}
                             scales: dict[int, int] = {}
                             precs: dict[int, int] = {}
                             opers: dict[int, int] = {}
 
-                            for oid, val in await self._async_walk(ent_value_oid):
+                            for oid, val in value_rows:
                                 try:
                                     idx = int(str(oid).split(".")[-1])
                                 except Exception:
                                     continue
                                 values[idx] = val
 
-                            for oid, val in await self._async_walk(ent_scale_oid):
+                            for oid, val in scale_rows:
                                 try:
                                     idx = int(str(oid).split(".")[-1])
                                 except Exception:
@@ -1786,7 +1983,7 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                                     continue
                                 scales[idx] = int(n)
 
-                            for oid, val in await self._async_walk(ent_prec_oid):
+                            for oid, val in prec_rows:
                                 try:
                                     idx = int(str(oid).split(".")[-1])
                                 except Exception:
@@ -1796,7 +1993,7 @@ OID_dot1qVlanCurrentUntaggedPorts = "1.3.6.1.2.1.17.7.1.4.2.1.5"
                                     continue
                                 precs[idx] = int(n)
 
-                            for oid, val in await self._async_walk(ent_oper_oid):
+                            for oid, val in oper_rows:
                                 try:
                                     idx = int(str(oid).split(".")[-1])
                                 except Exception:

--- a/custom_components/snmp_switch_manager/switch.py
+++ b/custom_components/snmp_switch_manager/switch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import ipaddress
 import logging
-import re
 from typing import Any, Dict, Optional
 
 from homeassistant.components.switch import SwitchEntity
@@ -15,10 +15,7 @@ from .const import (
     CONF_LEGACY_DEVICE_ID,
     CONF_SNMP_VERSION,
     SNMP_VERSION_V3,
-    CONF_PORT_RENAME_USER_RULES,
-    CONF_PORT_RENAME_DISABLED_DEFAULT_IDS,
     CONF_ICON_RULES,
-    DEFAULT_PORT_RENAME_RULES,
     CONF_INCLUDE_STARTS_WITH,
     CONF_INCLUDE_CONTAINS,
     CONF_INCLUDE_ENDS_WITH,
@@ -89,9 +86,9 @@ OPER_STATE = {
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    data = hass.data[DOMAIN][entry.entry_id]
-    client: SwitchSnmpClient = data["client"]
-    coordinator = data["coordinator"]
+    runtime = entry.runtime_data
+    client: SwitchSnmpClient = runtime.client
+    coordinator = runtime.coordinator
 
     entities: list[IfAdminSwitch] = []
     desired_if_indexes: set[int] = set()
@@ -116,42 +113,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
     ip_index = client.cache.get("ipIndex", {})
     ip_mask = client.cache.get("ipMask", {})
 
-    def _build_port_rename_rules() -> list[tuple[str, re.Pattern[str], str]]:
-        """Return ordered (id, compiled_regex, replace) rules for this entry."""
-        rules: list[tuple[str, re.Pattern[str], str]] = []
-
-        disabled = set(entry.options.get(CONF_PORT_RENAME_DISABLED_DEFAULT_IDS) or [])
-
-        # User rules first (highest priority)
-        for i, r in enumerate(entry.options.get(CONF_PORT_RENAME_USER_RULES) or []):
-            try:
-                pattern = str(r.get("pattern") or "").strip()
-                replace = str(r.get("replace") or "")
-                if not pattern:
-                    continue
-                rules.append((f"user_{i}", re.compile(pattern, re.IGNORECASE), replace))
-            except Exception:
-                # Ignore invalid user rules (they should be validated in the UI)
-                continue
-
-        # Built-in defaults next
-        for r in DEFAULT_PORT_RENAME_RULES:
-            rid = r.get("id") or ""
-            if not rid or rid in disabled:
-                continue
-            try:
-                pattern = str(r.get("pattern") or "").strip()
-                replace = str(r.get("replace") or "")
-                if not pattern:
-                    continue
-                rules.append((rid, re.compile(pattern, re.IGNORECASE), replace))
-            except Exception:
-                continue
-
-        return rules
-
-    port_rename_rules = _build_port_rename_rules()
-
     # Include/Exclude interface rules (simple string match; include wins over exclude)
     include_starts = [str(s).strip().lower() for s in (entry.options.get(CONF_INCLUDE_STARTS_WITH, []) or []) if str(s).strip()]
     include_contains = [str(s).strip().lower() for s in (entry.options.get(CONF_INCLUDE_CONTAINS, []) or []) if str(s).strip()]
@@ -173,19 +134,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
             or any(x in name_l for x in contains)
             or any(name_l.endswith(x) for x in ends)
         )
-
-    def _apply_port_rename(display_name: str) -> str:
-        """Apply all port rename rules in order (each rule substituted at most once)."""
-        if not display_name or not port_rename_rules:
-            return display_name
-        out = display_name
-        for _rid, rx, rep in port_rename_rules:
-            if rx.search(out):
-                try:
-                    out = rx.sub(rep, out, count=1)
-                except Exception:
-                    continue
-        return out
 
     # Vendor detection
     manufacturer = (client.cache.get("manufacturer") or "").lower()
@@ -327,10 +275,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     continue
 
 
-                # Apply per-device port rename rules to the *raw* interface name first.
-        # This allows rules to match vendor-specific raw strings (e.g. "Unit: ...") before any normalization.
-        # _apply_port_rename() closes over port_rename_rules
-        raw_for_display = _apply_port_rename((raw_name or "").strip())
+        # display_name from the coordinator already has rename rules applied by
+        # _postprocess_if_names in __init__.py. No further renaming needed here.
+        raw_for_display = (raw_name or "").strip()
 
         # Try to parse Gi1/0/1 style to preserve unit/slot/port in display name
         unit = 1
@@ -348,7 +295,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
             pass
 
         display = format_interface_name(raw_for_display, unit=unit, slot=slot, port=port)
-        display = _apply_port_rename(display)
 
         entities.append(
             IfAdminSwitch(
@@ -394,8 +340,6 @@ def _ip_for_index(if_index: int, ip_by_ifindex: Dict[int, str], ip_mask_by_ifind
     if not mask:
         return ip
     try:
-        import ipaddress
-
         net = ipaddress.IPv4Network((ip, mask), strict=False)
         return f"{ip}/{net.prefixlen}"
     except Exception:


### PR DESCRIPTION
So: basically, I had to do a whole lot of performance fixing on my Home Assistant when 2026.4.1 started crashing on me on startup. My investigation turned up a whole lot of things (of which snmp-switch-manager was only one, and not even the primary cause), and as part of my fixing of things I set Copilot loose on it to make some performance issues go away.

And it really is quite a bit more performant now, especially on startup, so I figured I'd contribute the code back.

Here we go --

Blocking I/O (A1, A2):
- Expand MIB preload in _ensure_engine to cover IF-MIB, ENTITY-MIB, BRIDGE-MIB, Q-BRIDGE-MIB, HOST-RESOURCES-MIB, IP-MIB, POWER-ETHERNET-MIB (was only 11 core modules).
- Disable MIB source search paths after preload (setMibSources()) to prevent any further filesystem access from the event loop.
- Add warm-up SNMP GET in async_initialize to flush remaining lazy pysnmp PDU/transport state before event-loop-native calls.

Startup performance (B1-B6):
- Remove duplicate async_config_entry_first_refresh() call in sensor.py; data is already populated by the time platforms are set up.
- Replace GETNEXT (_do_next_walk) with GETBULK (bulk_walk_cmd) walk with automatic GETNEXT fallback for SNMPv1 devices.
- Parallelize all static interface column walks (ifIndex, ifDescr, ifName, ifAlias, ifSpeed, ifHighSpeed, ifType) with asyncio.gather.
- Cache OID_dot1dBasePortIfIndex walk result; reuse bridge_ifindexes set for port classification instead of walking twice.
- Throttle IPv4 address polling (default 300s) to match uptime throttle; IPv4 data rarely changes at runtime.
- Move vendor-specific OID fetches (CBS350, Zyxel, MikroTik) to one-time initialization; skip on subsequent polls via _vendor_oids_fetched flag.

Correctness bugs (C1-C3):
- Fix CBS350 firmware poll: remove extra positional arg from _do_get_one call that caused silent TypeError every poll.
- Remove duplicate port rename logic from switch.py; coordinator now writes display_name via _postprocess_if_names in __init__.py.
- Parallelize PoE budget/used/Dell/standard walks and all env Dell OS6 GET/walk calls with asyncio.gather.

HA best practices (D1-D7):
- Add pysnmp>=6.2.6 to manifest.json requirements.
- Introduce SnmpSwitchRuntimeData dataclass; migrate from hass.data[DOMAIN][entry_id] to entry.runtime_data.
- Move service registration to async_setup (runs once per integration load, not once per device entry).
- Add async_close() to SwitchSnmpClient; call from async_unload_entry to release UDP transport handles on reload.
- Move import ipaddress to module level in switch.py.
- Add CONF_POLL_INTERVAL (5-300s, default 10s) to const.py; respect it in DataUpdateCoordinator construction.
- Detect SNMP auth errors via SnmpAuthError exception; raise ConfigEntryAuthFailed in async_setup_entry so HA prompts for reauthentication instead of silently retrying.
